### PR TITLE
often `|` and `:` are not part of URLs

### DIFF
--- a/weechat_hints.py
+++ b/weechat_hints.py
@@ -32,7 +32,7 @@ URL_PREFIXES = (
     "news",
     "git",
 )
-REGEX = re.compile(rf"(?:{'|'.join(URL_PREFIXES)}):\/\/[^{URL_DELIMITERS}]{{3,}}")
+REGEX = re.compile(rf"(?:{'|'.join(URL_PREFIXES)}):\/\/[^{URL_DELIMITERS}|:]{{3,}}")
 
 CLOSING_BRACKET_MAP = {
     "(": ")",


### PR DESCRIPTION
Just adds `|` and `:` to the list of delimiters where processing will stop.